### PR TITLE
enable caching for node_modules to speedup build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ node_js:
   - 'lts/*'
 before_script:
   - ng lint
+cache: 
+  directories:
+    - node_modules


### PR DESCRIPTION
Wenn npm nicht jedes Mal alle Pakete neu installieren muss, wird der Buildprozess in Travis insgesamt schneller.