### PR TITLE
NPM Script enhancements

### DIFF
--- a/mock/run-mockserver
+++ b/mock/run-mockserver
@@ -1,0 +1,2 @@
+#!/bin/bash
+java -jar sandbox run

--- a/mock/run-mockserver.sh
+++ b/mock/run-mockserver.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-BASEDIR="$( cd "$(dirname "$0")" ; pwd -P )"
-echo "$BASEDIR"
-java -jar \"$BASEDIR/sandbox\" run  --base=\"$BASEDIR\" --state=\"$BASEDIR/state.json\"

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
   "name": "sumz",
-  "version": "0.0.0",
+  "version": "2018.1.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
-    "build": "npm run-script gather-licenses && ng build -c production",
+    "start": "npm-run-all --parallel mockserver serve",
+    "prebuild": "npm-run-all lint test gather-licenses",
+    "build": "ng build -c production",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "gather-licenses": "cat ./src/app/credits/licenses-skeleton > ./src/app/credits/licenses.ts && nlf -c -r 1 | csv2json >> ./src/app/credits/licenses.ts"
+    "gather-licenses": "cp ./src/app/credits/licenses-skeleton ./src/app/credits/licenses.ts; nlf -c -r 1 | csv2json >> ./src/app/credits/licenses.ts",
+    "mockserver": "cd mock && run-mockserver",
+    "serve": "ng serve"
   },
   "private": true,
   "dependencies": {
@@ -51,6 +54,7 @@
     "karma-firefox-launcher": "^1.1.0",
     "karma-jasmine": "~1.1.1",
     "karma-jasmine-html-reporter": "^0.2.2",
+    "npm-run-all": "^4.1.3",
     "protractor": "^5.3.2",
     "ts-node": "~5.0.1",
     "tslint": "~5.9.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "ng lint",
     "e2e": "ng e2e",
     "gather-licenses": "cp ./src/app/credits/licenses-skeleton ./src/app/credits/licenses.ts; nlf -c -r 1 | csv2json >> ./src/app/credits/licenses.ts",
-    "mockserver": "cd mock && run-mockserver",
+    "mockserver": "cd mock && ./run-mockserver",
     "serve": "ng serve"
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "ng lint",
     "e2e": "ng e2e",
     "gather-licenses": "cp ./src/app/credits/licenses-skeleton ./src/app/credits/licenses.ts; nlf -c -r 1 | csv2json >> ./src/app/credits/licenses.ts",
-    "mockserver": "cd mock && ./run-mockserver",
+    "mockserver": "cd mock; ./run-mockserver",
     "serve": "ng serve"
   },
   "private": true,


### PR DESCRIPTION
Pünktlich zum Ende des Projekts ist mir aufgefallen, dass wir unsere NPM-Scripts deutlich vereinfachen können:
- `npm start` startet jetzt den Mockserver und das Angular Live Deployment parallel
  - geht in `bash`, `ps`, aber nicht `cmd`.
- `npm run build` lintet, testet und stellt alle Lizenzen zusammen, bevor der eigentliche Buildprozess beginnt
  - getestet in WSL. Erfordert, dass Chromium installiert und in der Umgebungsvariable `CHROME_BIN `referenziert wird
  - geht in `bash`, aber nicht `ps`, `cmd `(die benutzen antike Codierungen, ka wie man das konvertieren kann)
- die ng-Skripte direkt manuell aufzurufen ist weiterhin möglich

@Sta7e, wie war das noch mal mit dem BASEDIR im Shellskript? Ging das mal?
