### PR TITLE
Adjust to latest API definition

### DIFF
--- a/mock/scenario.js
+++ b/mock/scenario.js
@@ -13,7 +13,7 @@ exports.routes = [{
   handler: function (req, res) {
     req.body.id = Math.round(Math.random()*99999);
     state.scenarios.push(req.body)
-    res.json(req.body);
+    res.send(req.body.id);
     res.status(201);
   },
 },
@@ -30,7 +30,7 @@ exports.routes = [{
   verb: 'PUT',
   handler: function (req, res) {
     utils.setById(req.params.sId, state.scenarios, req.body);
-    res.json(req.body);
+    res.send(req.body.id);
   }
 },
 {

--- a/mock/scenario.js
+++ b/mock/scenario.js
@@ -11,9 +11,9 @@ exports.routes = [{
   route: '/scenarios',
   verb: 'POST',
   handler: function (req, res) {
-    req.body.id = Math.round(Math.random()*99999);
+    req.body.id = Math.round(Math.random() * 99999);
     state.scenarios.push(req.body)
-    res.send(req.body.id);
+    res.send(req.body.id + '');
     res.status(201);
   },
 },
@@ -30,7 +30,8 @@ exports.routes = [{
   verb: 'PUT',
   handler: function (req, res) {
     utils.setById(req.params.sId, state.scenarios, req.body);
-    res.send(req.body.id);
+    res.send(req.body.id + '');
+    res.type("application/text");
   }
 },
 {

--- a/src/app/api/api.d.ts
+++ b/src/app/api/api.d.ts
@@ -55,12 +55,12 @@ export interface SumzAPI {
     },
     '/scenarios': {
         GET: { response: Scenario[] },
-        POST: { body: Scenario, response: Scenario }
+        POST: { body: Scenario, response: number }
     },
     '/scenarios/:sId': {
         params: { sId: number },
         GET: { response: Scenario },
-        PUT: { body: Scenario, response: Scenario },
+        PUT: { body: Scenario, response: number },
         DELETE: {}
     },
 }

--- a/src/app/api/scenario.d.ts
+++ b/src/app/api/scenario.d.ts
@@ -29,7 +29,7 @@ export class Scenario {
 }
 
 export class AccountingFigure {
-    isHistoric: Boolean;
+    isHistoric: boolean;
     timeSeries: DataPoint[];
 }
 

--- a/src/app/create-scenario/create-scenario.component.ts
+++ b/src/app/create-scenario/create-scenario.component.ts
@@ -91,6 +91,7 @@ export class CreateScenarioComponent implements OnInit {
           },
           (error) => {
             this._alertService.error(`Das Szenario konnte nicht erstellt werden. (${error.statusText})`);
+            this.busy = false;
           },
           () => this.busy = false
         );

--- a/src/app/import-scenario/import-scenario.component.spec.ts
+++ b/src/app/import-scenario/import-scenario.component.spec.ts
@@ -1,8 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { ImportScenarioComponent } from './import-scenario.component';
-import { MaterialModule } from '../material.module';
 import { MatDialogRef } from '@angular/material';
+import { MaterialModule } from '../material.module';
+import { ScenariosService } from '../service/scenarios.service';
+import { ScenariosServiceMock } from '../service/scenarios.service.mock';
+import { ImportScenarioComponent } from './import-scenario.component';
+
 
 describe('ImportScenarioComponent', () => {
   let component: ImportScenarioComponent;
@@ -12,7 +14,7 @@ describe('ImportScenarioComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ImportScenarioComponent],
       imports: [MaterialModule],
-      providers: [{ provide: MatDialogRef, useValue: { close() { } } }],
+      providers: [{ provide: MatDialogRef, useValue: { close() { } } }, { provide: ScenariosService, useClass: ScenariosServiceMock }],
     })
       .compileComponents();
   }));


### PR DESCRIPTION
Anstatt nach `POST` und `PUT` direkt ein Szenario entgegenzunehmen, wird jetzt die ID des neuen Szenarios im Body erwartet. Im Anschluss führt der `ScenariosService` einen `GET`-Request auf dieses Szenario aus.

Bonus: `updateScenario` funktioniert jetzt erstmalig 🤷